### PR TITLE
fixing error running in a folder with space characters

### DIFF
--- a/bin/ngw
+++ b/bin/ngw
@@ -9,7 +9,7 @@ switch (process.argv[2]) {
         const entryPointPath = require.resolve('../lib/index');
         const tsNodePath = require.resolve('ts-node/dist/bin');
         const ngCommandArgs = process.argv.slice(2);
-        const executionPoint = [tsNodePath, entryPointPath].concat(ngCommandArgs).join(' ');
+        const executionPoint = '"'+[tsNodePath, entryPointPath].concat(ngCommandArgs).join('" "')+'"';
         
         execSync(`node ${executionPoint}`, {stdio: 'inherit'});
 


### PR DESCRIPTION
facing an issue when running ngw in a windows 10 environment (didn't try other OS) and having the full path of my repository that contains a folder with a space character in its name. Changing the folder name it works as expected but this is a little bit annoying. The error message is  below.

Not working folder
C:\Users\myuser\Documents\myfolder\\_**GIT Repos**_\myrepo

Working folder path 
C:\Users\myuser\Documents\myfolder\\_**GITRepos**_\myrepo

```
module.js:549
    throw err;
    ^

Error: Cannot find module 'C:\Users\myuser\Documents\myfolder\GIT'
    at Function.Module._resolveFilename (module.js:547:15)
    at Function.Module._load (module.js:474:25)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
    at bootstrap_node.js:609:3
child_process.js:644
    throw err;
    ^

Error: Command failed: node C:\Users\myuser\Documents\myfolder\GIT Repos\myrepo\node_modules\ngw\node_modules\ts-node\dist\bin.js C:\Users\myuser\Documents\myfolder\GIT Repos\myrepo\node_modules\ngw\lib\index.js build --aot=true --base-href=/app/
    at checkExecSyncError (child_process.js:601:13)
    at execSync (child_process.js:641:13)
    at Object.<anonymous> (C:\Users\myuser\Documents\myfolder\GIT Repos\myrepo\node_modules\ngw\bin\ngw:14:9)
    at Module._compile (module.js:652:30)
    at Object.Module._extensions..js (module.js:663:10)
    at Module.load (module.js:565:32)
    at tryModuleLoad (module.js:505:12)
    at Function.Module._load (module.js:497:3)
    at Function.Module.runMain (module.js:693:10)
    at startup (bootstrap_node.js:188:16)
```
got a solution changing line 12 from
`const executionPoint = [tsNodePath, entryPointPath].concat(ngCommandArgs).join(' ');`

to
`const executionPoint = '"'+[tsNodePath, entryPointPath].concat(ngCommandArgs).join('" "')+'"';`